### PR TITLE
made the makefile work properly and less chatty

### DIFF
--- a/makefile
+++ b/makefile
@@ -1,3 +1,5 @@
+RM+=-rfv
+
 CC     := gcc
 CFLAGS := -Wall -O3
 DFLAGS := -Wall -g
@@ -16,29 +18,30 @@ SOURCESPATHS := $(wildcard $(SRC)/*.c)
 OBJECTS      := $(SOURCESPATHS:$(SRC)/%.c=$(BUILD)/%.o)
 DEPS         := $(SOURCESPATHS:$(SRC)/%.c=$(DEPSDIR)/%.d)
 
+build: $(BINARY)
+
 $(BINARY): $(OBJECTS)
-	$(LD) $(CFLAGS) -I$(INCLUDE) $(OBJECTS) -o $(BINARY) $(LIBS) 
+	@echo Linking object into $@
+	@$(LD) $(CFLAGS) -I$(INCLUDE) $(OBJECTS) -o $@ $(LIBS) 
 
 install: $(BINARY)
-	cp $(BINARY) /usr/bin/
+	@cp -uv $(BINARY) /usr/bin/
 
 -include $(DEPSDIR)/$(DEPS)
 $(BUILD)/%.o: $(SRC)/%.c
-	mkdir -p $(dir $@)
-	$(CC) $(CFLAGS) -I$(INCLUDE) -c $< -o $@ -MMD
+	@mkdir -p $(dir $@)
+	@echo Compiling $< into $@
+	@$(CC) $(CFLAGS) -I$(INCLUDE) -c $< -o $@ -MMD
 
 clean:
-	$(RM) $(BUILD)/*
+	@$(RM) $(BUILD)
 
 wipe: clean
-	$(RM) $(BINARY)
+	@$(RM) $(BINARY)
 
-re: fullclean
-	$(MAKE) $(BINARY)
+re: wipe build
 
 run: $(BINARY)
 	./$(BINARY)
 
-rerun:
-	$(MAKE) re
-	$(MAKE) run
+rerun: re run


### PR DESCRIPTION
make re required make fullclean which doesn't exist so I replaced the req with make wipe

muted the commands and opted to using muted echos to tell what's happening instead

added verbose flag to commands: $(RM) and 'cp'. to have a record of what file was deleted/modified
added update flag to command: 'cp'. to only modify the install in case of a difference
added force and recursive flags to command: $(RM). to delete the entire ./build/ directory instead of the individual objects and dep files

added make build to help with the dependencies of make re and the lot

modified how make re and the lot called the other make commands to remove annoying recursive makefile terminal output


